### PR TITLE
College Score is div not h1

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -35,8 +35,8 @@ const Header = () => {
         <Toolbar disableGutters sx={{ justifyContent: "space-between" }}>
           {/* Logo which also functions as Home Link */}
           <Typography
-            variant="h6" // style as h6 but use h1 for semantics
-            component="h1"
+            variant="h6"
+            component="div"
             sx={{
               fontWeight: 700,
               textDecoration: "none",


### PR DESCRIPTION
Like we discussed, the College Score text in the header should not be the h1 component. Changed it to a div. Once we import the logo, we can change it to an svg with alt text.