### PR TITLE
default exports for blank page files

### DIFF
--- a/src/app/colleges/[slug]/page.tsx
+++ b/src/app/colleges/[slug]/page.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+export default function CollegeSlugPage({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  return (
+    <div>
+      <h1>College: {params.slug}</h1>
+      <p>This page is under construction.</p>
+    </div>
+  );
+}

--- a/src/app/colleges/page.tsx
+++ b/src/app/colleges/page.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function CollegePage({ params }: { params: { slug: string } }) {
+  return (
+    <div>
+      <h1>College: {params.slug}</h1>
+      <p>This page is under construction.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
vercel gets upset about blank page files. No default export is bad so I just put this placeholder in for now.