### PR TITLE
Add contributing link to footer

### DIFF
--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -39,7 +39,7 @@ const Footer = () => {
               <Typography variant="body2">
                 Learn how to contribute{" "}
                 <MuiLink
-                  href="https://github.com/collegescore/documentation" // TODO: replace with link to contributing md file once the overhaul branch is merged
+                  href="https://github.com/collegescore/documentation/blob/main/CONTRIBUTING.md"
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label="Learn how to contribute on GitHub (opens in a new tab)"


### PR DESCRIPTION
Jen mentioned that since we are open source we should have a link on the site to the github repository. The link I have in there right now just takes you to the documentation repo, but once we merge the documentation overhaul branch we should update the link to point to the contributing.md file.

<img width="1353" height="345" alt="Screenshot 2026-03-13 at 11 19 26 AM" src="https://github.com/user-attachments/assets/dd391d6c-fcac-495e-a4bd-b83818609d8b" />
<img width="434" height="288" alt="Screenshot 2026-03-13 at 11 25 47 AM" src="https://github.com/user-attachments/assets/784ce15a-641e-452a-b2b2-67f9b3bd48b3" />
